### PR TITLE
升级到5.0.1版本，有个问题需要谷主解决

### DIFF
--- a/Source/FairyGUI/FairyGUI.Build.cs
+++ b/Source/FairyGUI/FairyGUI.Build.cs
@@ -56,3 +56,6 @@ public class FairyGUI : ModuleRules
 			);
 	}
 }
+
+
+

--- a/Source/FairyGUI/Private/FairyApplication.cpp
+++ b/Source/FairyGUI/Private/FairyApplication.cpp
@@ -224,7 +224,10 @@ void UFairyApplication::PlaySound(const FString& URL, float VolumnScale)
     if (SoundItem.IsValid())
     {
         SoundItem->Load();
-        FSlateApplication::Get().PlaySound(*SoundItem->Sound);
+        if (SoundItem->Sound.IsValid())
+        {
+            FSlateApplication::Get().PlaySound(*SoundItem->Sound);
+        }
     }
 }
 

--- a/Source/FairyGUI/Private/UI/GComponent.cpp
+++ b/Source/FairyGUI/Private/UI/GComponent.cpp
@@ -20,7 +20,7 @@ UGComponent::UGComponent() :
 {
     DisplayObject = RootContainer = SNew(SContainer).GObject(this);
     DisplayObject->SetOpaque(false);
-
+    
     Container = SNew(SContainer);
     Container->SetOpaque(false);
     RootContainer->AddChild(Container.ToSharedRef());

--- a/Source/FairyGUI/Private/UI/GList.cpp
+++ b/Source/FairyGUI/Private/UI/GList.cpp
@@ -832,7 +832,7 @@ void UGList::ScrollToView(int32 Index, bool bAnimation, bool bSetFirst)
         verifyf(Index >= 0 && Index < VirtualItems.Num(), TEXT("Invalid child index"));
 
         if (bLoop)
-            Index = FMath::FloorToFloat(FirstIndex / NumItems) * NumItems + Index;
+            Index = FMath::FloorToFloat(static_cast<float>(FirstIndex) / NumItems) * NumItems + Index;
 
         FBox2D rect;
         FItemInfo& ii = VirtualItems[Index];
@@ -1072,19 +1072,19 @@ FVector2D UGList::GetSnappingPosition(const FVector2D& InPoint)
         FVector2D ret = InPoint;
         if (Layout == EListLayoutType::SingleColumn || Layout == EListLayoutType::FlowHorizontal)
         {
-            int32 index = GetIndexOnPos1(ret.Y, false);
+            int32 index = GetIndexOnPos1(reinterpret_cast<float&>(ret.Y), false);
             if (index < VirtualItems.Num() && InPoint.Y - ret.Y > VirtualItems[index].Size.Y / 2 && index < RealNumItems)
                 ret.Y += VirtualItems[index].Size.Y + LineGap;
         }
         else if (Layout == EListLayoutType::SingleRow || Layout == EListLayoutType::FlowVertical)
         {
-            int32 index = GetIndexOnPos2(ret.X, false);
+            int32 index = GetIndexOnPos2(reinterpret_cast<float&>(ret.X), false);
             if (index < VirtualItems.Num() && InPoint.X - ret.X > VirtualItems[index].Size.X / 2 && index < RealNumItems)
                 ret.X += VirtualItems[index].Size.X + ColumnGap;
         }
         else
         {
-            int32 index = GetIndexOnPos3(ret.X, false);
+            int32 index = GetIndexOnPos3(reinterpret_cast<float&>(ret.X), false);
             if (index < VirtualItems.Num() && InPoint.X - ret.X > VirtualItems[index].Size.X / 2 && index < RealNumItems)
                 ret.X += VirtualItems[index].Size.X + ColumnGap;
         }

--- a/Source/FairyGUI/Private/Widgets/BitmapFontRun.cpp
+++ b/Source/FairyGUI/Private/Widgets/BitmapFontRun.cpp
@@ -79,24 +79,24 @@ FVector2D FBitmapFontRun::GetLocationAt(const TSharedRef< ILayoutBlock >& Block,
     return Block->GetLocationOffset();
 }
 
-int32 FBitmapFontRun::OnPaint(const FPaintArgs& Args, const FTextLayout::FLineView& Line, const TSharedRef< ILayoutBlock >& Block, const FTextBlockStyle& DefaultStyle, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
+int32 FBitmapFontRun::OnPaint(const FPaintArgs& PaintArgs, const FTextArgs& TextArgs, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
 {
     if (Glyph == nullptr)
         return LayerId;
 
     // The block size and offset values are pre-scaled, so we need to account for that when converting the block offsets into paint geometry
     const float InverseScale = Inverse(AllottedGeometry.Scale);
-
+    
     FLinearColor FinalColorAndOpacity;
     if (Font->bCanTint)
-        FinalColorAndOpacity = InWidgetStyle.GetColorAndOpacityTint() * DefaultStyle.ColorAndOpacity.GetSpecifiedColor();
+        FinalColorAndOpacity = InWidgetStyle.GetColorAndOpacityTint() * TextArgs.DefaultStyle.ColorAndOpacity.GetSpecifiedColor();
     else
         FinalColorAndOpacity = InWidgetStyle.GetColorAndOpacityTint();
     const ESlateDrawEffect DrawEffects = bParentEnabled ? ESlateDrawEffect::None : ESlateDrawEffect::DisabledEffect;
     FSlateDrawElement::MakeBox(
         OutDrawElements,
         ++LayerId,
-        AllottedGeometry.ToPaintGeometry(Glyph->Size, FSlateLayoutTransform(TransformPoint(InverseScale, Block->GetLocationOffset()) + Glyph->Offset)),
+        AllottedGeometry.ToPaintGeometry(Glyph->Size, FSlateLayoutTransform(TransformPoint(InverseScale, TextArgs.Block->GetLocationOffset()) + Glyph->Offset)),
         &Brush,
         DrawEffects,
         FinalColorAndOpacity

--- a/Source/FairyGUI/Private/Widgets/LoaderRun.cpp
+++ b/Source/FairyGUI/Private/Widgets/LoaderRun.cpp
@@ -102,11 +102,12 @@ FVector2D FLoaderRun::GetLocationAt(const TSharedRef< ILayoutBlock >& Block, int
     return Block->GetLocationOffset();
 }
 
-int32 FLoaderRun::OnPaint(const FPaintArgs& Args, const FTextLayout::FLineView& Line, const TSharedRef< ILayoutBlock >& Block, const FTextBlockStyle& DefaultStyle, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
+int32 FLoaderRun::OnPaint(const FPaintArgs& PaintArgs, const FTextArgs& TextArgs, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const
 {
+
     const float InverseScale = Inverse(AllottedGeometry.Scale);
-    const FGeometry WidgetGeometry = AllottedGeometry.MakeChild(TransformVector(InverseScale, Block->GetSize()), FSlateLayoutTransform(TransformPoint(InverseScale, Block->GetLocationOffset())));
-    return Children[0]->Paint(Args, WidgetGeometry, MyCullingRect, OutDrawElements, LayerId, InWidgetStyle, bParentEnabled);
+    const FGeometry WidgetGeometry = AllottedGeometry.MakeChild(TransformVector(InverseScale, TextArgs.Block->GetSize()), FSlateLayoutTransform(TransformPoint(InverseScale, TextArgs.Block->GetLocationOffset())));
+    return Children[0]->Paint(PaintArgs, WidgetGeometry, MyCullingRect, OutDrawElements, LayerId, InWidgetStyle, bParentEnabled);
 }
 
 TSharedRef< ILayoutBlock > FLoaderRun::CreateBlock(int32 BeginIndex, int32 EndIndex, FVector2D Size, const FLayoutBlockTextContext& TextContext, const TSharedPtr< IRunRenderer >& Renderer)

--- a/Source/FairyGUI/Private/Widgets/Mesh/PolygonMesh.cpp
+++ b/Source/FairyGUI/Private/Widgets/Mesh/PolygonMesh.cpp
@@ -103,12 +103,12 @@ void FPolygonMesh::DrawOutline(FVertexHelper& Helper)
     int32 start = k - numVertices;
     for (int32 i = 0; i < numVertices; i++)
     {
-        const FVector2D& p0 = Helper.Vertices[start + i].Position;
+        const FVector2D& p0 = FVector2D(Helper.Vertices[start + i].Position);
         FVector2D p1;
         if (i < numVertices - 1)
-            p1 = Helper.Vertices[start + i + 1].Position;
+            p1 = FVector2D(Helper.Vertices[start + i + 1].Position);
         else
-            p1 = Helper.Vertices[start].Position;
+            p1 = FVector2D(Helper.Vertices[start].Position);
 
         FVector2D widthVector(p1.Y - p0.Y, p0.X - p1.X);
         widthVector.Normalize();

--- a/Source/FairyGUI/Private/Widgets/Mesh/VertexHelper.cpp
+++ b/Source/FairyGUI/Private/Widgets/Mesh/VertexHelper.cpp
@@ -30,7 +30,7 @@ void FVertexHelper::AddVertex(const FVector2D& Position, const FColor& Color)
 void FVertexHelper::AddVertex(const FVector2D& Position, const FColor& Color, const FVector2D& TexCoords)
 {
     FSlateVertex Vertex;
-    Vertex.Position = Position;
+    Vertex.Position = FVector2f(Position);
     Vertex.Color = Color;
     Vertex.TexCoords[0] = TexCoords.X;
     Vertex.TexCoords[1] = TexCoords.Y;
@@ -117,8 +117,8 @@ const FVector2D& FVertexHelper::GetPosition(int32 Index)
 {
     if (Index < 0)
         Index = Vertices.Num() + Index;
-
-    return Vertices[Index].Position;
+    
+    return FVector2D(Vertices[Index].Position);
 }
 
 FVector2D FVertexHelper::GetUVAtPosition(const FVector2D& Position, bool bUsePercent)

--- a/Source/FairyGUI/Private/Widgets/Mesh/VertexHelper.cpp
+++ b/Source/FairyGUI/Private/Widgets/Mesh/VertexHelper.cpp
@@ -118,7 +118,7 @@ const FVector2D& FVertexHelper::GetPosition(int32 Index)
     if (Index < 0)
         Index = Vertices.Num() + Index;
     
-    return FVector2D(Vertices[Index].Position);
+    return *new FVector2D(Vertices[Index].Position);
 }
 
 FVector2D FVertexHelper::GetUVAtPosition(const FVector2D& Position, bool bUsePercent)

--- a/Source/FairyGUI/Private/Widgets/NGraphics.cpp
+++ b/Source/FairyGUI/Private/Widgets/NGraphics.cpp
@@ -91,7 +91,7 @@ void FNGraphics::Paint(const FGeometry& AllottedGeometry,
     int32 VerticeLength = Vertices.Num();
     for (int32 i = 0; i < VerticeLength; i++)
     {
-        Vertices[i].Position = AllottedGeometry.LocalToAbsolute(PositionsBackup[i]);
+        Vertices[i].Position =FVector2f(AllottedGeometry.LocalToAbsolute(PositionsBackup[i]));
     }
 
     FSlateDrawElement::MakeCustomVerts(OutDrawElements, LayerId, ResourceHandle, Vertices, Triangles, nullptr, 0, 0, DrawEffects);
@@ -157,7 +157,7 @@ void FNGraphics::UpdateMeshNow()
         AlphaBackup[i] = Vertex.Color.A;
         Vertex.Color.A = (uint8)FMath::Clamp<int32>(FMath::TruncToInt(Vertex.Color.A * UsingAlpha), 0, 255),
 
-        PositionsBackup[i] = Vertex.Position;
+        PositionsBackup[i] = FVector2D(Vertex.Position);
     }
 
     Vertices += Helper.Vertices;

--- a/Source/FairyGUI/Private/Widgets/NTexture.cpp
+++ b/Source/FairyGUI/Private/Widgets/NTexture.cpp
@@ -8,10 +8,10 @@ UNTexture* UNTexture::GetWhiteTexture()
     if (WhiteTexture == nullptr)
     {
         UTexture2D* NativeTexture = UTexture2D::CreateTransient(2, 2);
-        uint8* MipData = (uint8*)NativeTexture->PlatformData->Mips[0].BulkData.Lock(LOCK_READ_WRITE);
+        uint8* MipData = (uint8*)NativeTexture->GetPlatformData()->Mips[0].BulkData.Lock(LOCK_READ_WRITE);
         for (int32 i = 0; i < 16; i++)
             *(MipData + i) = 255;
-        NativeTexture->PlatformData->Mips[0].BulkData.Unlock();
+        NativeTexture->GetPlatformData()->Mips[0].BulkData.Unlock();
 #if WITH_EDITORONLY_DATA
         NativeTexture->CompressionNone = true;
         NativeTexture->MipGenSettings = TMGS_NoMipmaps;

--- a/Source/FairyGUI/Private/Widgets/SDisplayObject.cpp
+++ b/Source/FairyGUI/Private/Widgets/SDisplayObject.cpp
@@ -4,7 +4,6 @@
 #include "UI/GObject.h"
 
 bool SDisplayObject::bMindVisibleOnly = false;
-FNoChildren SDisplayObject::NoChildrenInstance;
 FName SDisplayObject::SDisplayObjectTag("SDisplayObjectTag");
 
 SDisplayObject::SDisplayObject() :
@@ -29,7 +28,11 @@ const FVector2D& SDisplayObject::GetPosition() const
     if (!GetRenderTransform().IsSet())
         return FVector2D::ZeroVector;
     else
+    {
         return GetRenderTransform()->GetTranslation();
+    }
+        
+        
 }
 
 void SDisplayObject::SetPosition(const FVector2D& InPosition)
@@ -108,13 +111,14 @@ void SDisplayObject::SetInteractable(bool bInInteractable)
 
 void SDisplayObject::UpdateVisibilityFlags()
 {
+    
     bool HitTestFlag = bInteractable && bTouchable;
     if (!bVisible)
         SetVisibility(EVisibility::Collapsed);
     else if (!HitTestFlag)
         SetVisibility(EVisibility::HitTestInvisible);
     else  if (GObject.IsValid() && GObject->GetHitArea() != nullptr)
-        Visibility.BindRaw(this, &SDisplayObject::GetVisibilityFlags);
+        SetVisibility(TAttribute<EVisibility>(this, &SDisplayObject::GetVisibilityFlags));   
     else if (!bOpaque)
         SetVisibility(EVisibility::SelfHitTestInvisible);
     else
@@ -157,7 +161,7 @@ FVector2D SDisplayObject::ComputeDesiredSize(float) const
 
 FChildren* SDisplayObject::GetChildren()
 {
-    return &NoChildrenInstance;
+    return &FNoChildren::NoChildrenInstance;
 }
 
 void SDisplayObject::OnArrangeChildren(const FGeometry& AllottedGeometry, FArrangedChildren& ArrangedChildren) const
@@ -226,6 +230,11 @@ FReply SDisplayObject::OnMouseWheel(const FGeometry& MyGeometry, const FPointerE
         return Obj->GetApp()->OnWidgetMouseWheel(AsShared(), MyGeometry, MouseEvent);
     else
         return FReply::Unhandled();
+}
+
+void SDisplayObject::SetVisibility(TAttribute<EVisibility> InVisibility)
+{
+    SWidget::SetVisibility(InVisibility);
 }
 
 bool SDisplayObject::IsWidgetOnStage(const TSharedPtr<SWidget>& InWidget)

--- a/Source/FairyGUI/Private/Widgets/SDisplayObject.cpp
+++ b/Source/FairyGUI/Private/Widgets/SDisplayObject.cpp
@@ -29,10 +29,11 @@ const FVector2D& SDisplayObject::GetPosition() const
         return FVector2D::ZeroVector;
     else
     {
-        return GetRenderTransform()->GetTranslation();
+        FVector2D& fv = *new FVector2D() ;
+        fv = GetRenderTransform()->GetTranslation();
+        return  fv;
     }
-        
-        
+    
 }
 
 void SDisplayObject::SetPosition(const FVector2D& InPosition)

--- a/Source/FairyGUI/Public/UI/GObjectPool.h
+++ b/Source/FairyGUI/Public/UI/GObjectPool.h
@@ -13,6 +13,11 @@ public:
 
     virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
 
+    virtual FString GetReferencerName() const override
+    {
+        return TEXT("FGObjectPool");
+    };
+
 private:
     TMap<FString, TArray<UGObject*>> Pool;
 };

--- a/Source/FairyGUI/Public/UI/PackageItem.h
+++ b/Source/FairyGUI/Public/UI/PackageItem.h
@@ -26,6 +26,11 @@ public:
 
     virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
 
+    virtual FString GetReferencerName() const override
+    {
+        return TEXT("FPackageItem");
+    };
+
 public:
     UUIPackage* Owner;
 

--- a/Source/FairyGUI/Public/Widgets/BitmapFont.h
+++ b/Source/FairyGUI/Public/Widgets/BitmapFont.h
@@ -25,5 +25,10 @@ struct FAIRYGUI_API FBitmapFont : public FGCObject
 
     UNTexture* Texture;
 
+    virtual FString GetReferencerName() const override
+    {
+        return TEXT("BitmapFont");
+    };
+
     virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
 };

--- a/Source/FairyGUI/Public/Widgets/BitmapFontRun.h
+++ b/Source/FairyGUI/Public/Widgets/BitmapFontRun.h
@@ -31,8 +31,8 @@ public:
 
     virtual TSharedRef< ILayoutBlock > CreateBlock(int32 StartIndex, int32 EndIndex, FVector2D Size, const FLayoutBlockTextContext& TextContext, const TSharedPtr< IRunRenderer >& Renderer) override;
 
-    virtual int32 OnPaint(const FPaintArgs& Args, const FTextLayout::FLineView& Line, const TSharedRef< ILayoutBlock >& Block, const FTextBlockStyle& DefaultStyle, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const override;
-
+    virtual int32 OnPaint(const FPaintArgs& PaintArgs, const FTextArgs& TextArgs, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const override;
+                  
     virtual const TArray< TSharedRef<SWidget> >& GetChildren() override;
 
     virtual void ArrangeChildren(const TSharedRef< ILayoutBlock >& Block, const FGeometry& AllottedGeometry, FArrangedChildren& ArrangedChildren) const override;

--- a/Source/FairyGUI/Public/Widgets/LoaderRun.h
+++ b/Source/FairyGUI/Public/Widgets/LoaderRun.h
@@ -30,7 +30,7 @@ public:
 
     virtual TSharedRef< ILayoutBlock > CreateBlock(int32 StartIndex, int32 EndIndex, FVector2D Size, const FLayoutBlockTextContext& TextContext, const TSharedPtr< IRunRenderer >& Renderer) override;
 
-    virtual int32 OnPaint(const FPaintArgs& Args, const FTextLayout::FLineView& Line, const TSharedRef< ILayoutBlock >& Block, const FTextBlockStyle& DefaultStyle, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const override;
+    virtual int32 OnPaint(const FPaintArgs& PaintArgs, const FTextArgs& TextArgs, const FGeometry& AllottedGeometry, const FSlateRect& MyCullingRect, FSlateWindowElementList& OutDrawElements, int32 LayerId, const FWidgetStyle& InWidgetStyle, bool bParentEnabled) const override;
 
     virtual const TArray< TSharedRef<SWidget> >& GetChildren() override;
 
@@ -54,6 +54,11 @@ public:
     virtual ERunAttributes GetRunAttributes() const override;
 
     virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
+
+    virtual FString GetReferencerName() const override
+    {
+        return TEXT("FLoaderRun");
+    };
 
 protected:
     FLoaderRun(UFairyApplication* App, const FHTMLElement& HTMLElement, const TSharedRef< const FString >& InText, const FTextRange& InRange);

--- a/Source/FairyGUI/Public/Widgets/NGraphics.h
+++ b/Source/FairyGUI/Public/Widgets/NGraphics.h
@@ -35,6 +35,11 @@ public:
 
     virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
 
+    virtual FString GetReferencerName() const override
+    {
+        return TEXT("FNGraphics");
+    };
+
 private:
     void UpdateMeshNow();
 

--- a/Source/FairyGUI/Public/Widgets/SContainer.h
+++ b/Source/FairyGUI/Public/Widgets/SContainer.h
@@ -5,10 +5,49 @@
 class FAIRYGUI_API SContainer : public SDisplayObject
 {
 public:
-    SLATE_BEGIN_ARGS(SContainer) :
-        _GObject(nullptr)
-    {}
+    
+    class FSlot : public TSlotBase<FSlot>
+    {
+    public:	
+        SLATE_SLOT_BEGIN_ARGS(FSlot, TSlotBase<FSlot>)
+        SLATE_SLOT_END_ARGS()
+
+        FSlot(const TSharedRef<SWidget>& InWidget);
+        
+        FSlot(const FChildren& InParent);
+
+        FSlot()
+        {
+        }
+
+        void Construct(const FChildren& SlotOwner, FSlotArguments&& InArg);
+        
+    };
+    
+    static FSlot::FSlotArguments Slot(const TSharedRef<SWidget>& InWidget)
+    {
+        return FSlot::FSlotArguments(MakeUnique<FSlot>(InWidget));
+    }
+    
+    using SContainerSlotArguments = TPanelChildren<FSlot>::FScopedWidgetSlotArguments;
+    
+    SContainerSlotArguments AddSlot(const TSharedRef<SWidget>& InWidget)
+    {
+        return InsertSlot(InWidget,INDEX_NONE);
+    }
+    
+    SContainerSlotArguments InsertSlot(const TSharedRef<SWidget>& InWidget,int32 Index = INDEX_NONE)
+    {
+        return SContainerSlotArguments{MakeUnique<FSlot>(InWidget), this->Children, Index};
+    }
+
+    SLATE_BEGIN_ARGS(SContainer) 
+       : _GObject(nullptr)
+    {
+        _Visibility = EVisibility::SelfHitTestInvisible;
+    }
     SLATE_ARGUMENT(UGObject*, GObject)
+    SLATE_SLOT_ARGUMENT( SContainer::FSlot, Slots )
     SLATE_END_ARGS()
 
     SContainer();
@@ -30,5 +69,5 @@ public:
     virtual FChildren* GetChildren() override;
 
 protected:
-    TPanelChildren<FSlotBase> Children;
+    TPanelChildren<FSlot> Children;
 };

--- a/Source/FairyGUI/Public/Widgets/SDisplayObject.h
+++ b/Source/FairyGUI/Public/Widgets/SDisplayObject.h
@@ -13,6 +13,7 @@ public:
         _GObject(nullptr),
         _Tag(SDisplayObject::SDisplayObjectTag)
     {
+        _Visibility = EVisibility::SelfHitTestInvisible;
     }
     SLATE_ARGUMENT(UGObject*, GObject)
     SLATE_ARGUMENT(FName, Tag)
@@ -53,6 +54,8 @@ public:
     virtual void OnMouseLeave(const FPointerEvent& MouseEvent) override;
     virtual FReply OnMouseWheel(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;
 
+    virtual void SetVisibility( TAttribute<EVisibility> InVisibility ) override final;
+
     TWeakObjectPtr<class UGObject> GObject;
 
     static bool IsWidgetOnStage(const TSharedPtr<SWidget>& InWidget);
@@ -77,7 +80,4 @@ protected:
     FVector2D Size;
 
     static bool bMindVisibleOnly;
-
-private:
-    static FNoChildren NoChildrenInstance;
 };

--- a/Source/FairyGUI/Public/Widgets/SMovieClip.h
+++ b/Source/FairyGUI/Public/Widgets/SMovieClip.h
@@ -17,6 +17,11 @@ struct FAIRYGUI_API FMovieClipData : public FGCObject
 
     FMovieClipData();
     virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
+
+    virtual FString GetReferencerName() const override
+    {
+        return TEXT("FMovieClip");
+    };
 };
 
 class FAIRYGUI_API SMovieClip : public SFImage

--- a/Source/FairyGUI/Public/Widgets/STextInput.h
+++ b/Source/FairyGUI/Public/Widgets/STextInput.h
@@ -28,5 +28,5 @@ public:
     TSharedRef<class SMultiLineEditableText> Widget;
 
 protected:
-    FSimpleSlot ChildSlot;
+    FSingleWidgetChildrenWithSlot ChildSlot;
 };


### PR DESCRIPTION
遇到的问题，第二条不确定是否为官方BUG，希望谷主能指点指点。太长时间没接触UE跟C++了。
1. 由于UE5编辑器BUG，在编辑器模式中，图片资源在首次加载时不能正确的读取图片大小（32X32），需要在编辑器启动时右键重新加载图片。
2. 打包运行时候，出现Slate 跨线程访问资源报错。AddChild 添加到第12个 UGComponent时报错。  
具体报错如下
Assertion failed: IsInGameThread() || IsInSlateThread() [File:D:\build\++UE5\Sync\Engine\Source\Runtime\SlateCore\Private\Widgets\SWidget.cpp] [Line: 1222] 
Slate can only be accessed from the GameThread or the SlateLoadingThread!